### PR TITLE
add uniq-region recipe

### DIFF
--- a/recipes/uniq-region
+++ b/recipes/uniq-region
@@ -1,0 +1,1 @@
+(uniq-region :fetcher codeberg :repo "yabobay/emacs-uniq-region")


### PR DESCRIPTION
### Brief summary of what the package does

Provides `uniq-region` interactive function which deletes duplicate lines from region except for whitespace (might make that a customization option in the future).

### Direct link to the package repository

https://codeberg.org/yabobay/emacs-uniq-region

### Your association with the package

I created this package.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

<!-- Please confirm by replacing `[]` with `[x]`: -->

- [X] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses)
- [X] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [X] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [X] My elisp byte-compiles cleanly
- [X] I've used `M-x checkdoc` to check the package's documentation strings
- [X] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)

<!-- After submitting, please fix any problems the CI reports. -->
